### PR TITLE
add support for doc comment contracts

### DIFF
--- a/c3-ts-mode.el
+++ b/c3-ts-mode.el
@@ -311,26 +311,19 @@
   ;; NOTE Earlier rules have precedence over later rules
   (treesit-font-lock-rules
    :language 'c3
+   :feature 'doc-comment
+   '((doc_comment_contract
+      name: (at_ident) @font-lock-builtin-face)
+     (doc_comment_contract
+      mutability_contract: (_) @font-lock-constant-face)
+     (["<*" "*>"] @font-lock-doc-face)
+     (doc_comment_text) @font-lock-doc-face)
+
+   :language 'c3
    :feature 'comment
    '((line_comment) @font-lock-comment-face
      (block_comment) @font-lock-comment-face
      (doc_comment) @font-lock-doc-face)
-
-   :language 'c3
-   :feature 'doc-comment
-   :override 'append
-   `((doc_comment_contract (at_ident) @bold
-      (:match ,(rx
-                bos
-                "@"
-                (or
-                 "param"
-                 "return"
-                 "deprecated"
-                 "require"
-                 "ensure"
-                 "pure")
-                eos) @bold)))
 
    :language 'c3
    :feature 'literal


### PR DESCRIPTION
I'm not very familiar with font-lock so I chose to use `@font-lock-constant-face` for `[&in]` as it looked fine with my theme, but there may be something that fits better.

I'm not sure that I did this the "correct" way, but it seems to work

before:
![image](https://github.com/user-attachments/assets/57c7fe62-0373-4918-a656-5eb1b94acba5)

after:
![image](https://github.com/user-attachments/assets/990800e5-3fa4-447a-9c22-1785645a78a3)
