### PR TITLE
Simplify auto-mode-alist entry: use 1 entry for the 3 extensions.

### DIFF
--- a/c3-ts-mode.el
+++ b/c3-ts-mode.el
@@ -656,9 +656,7 @@
     (treesit-major-mode-setup)))
 
 (when (treesit-ready-p 'c3)
-  (add-to-list 'auto-mode-alist '("\\.c3\\'" . c3-ts-mode))
-  (add-to-list 'auto-mode-alist '("\\.c3i\\'" . c3-ts-mode))
-  (add-to-list 'auto-mode-alist '("\\.c3t\\'" . c3-ts-mode)))
+  (add-to-list 'auto-mode-alist '("\\.c3[it]?\\'" . c3-ts-mode)))
 
 (eval-after-load 'compile
   (lambda()


### PR DESCRIPTION
Use ``[it]?`` regexp to describe optional portion of the file extension.  This replaces the 3 entries in auto-mode-alist by a single one. 